### PR TITLE
Drop default value for ssl_certificate_arn

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -9,11 +9,11 @@ Amazon Web Services deployment is driven by [Terraform](https://terraform.io/) a
 
 ## AWS Credentials
 
-Using the AWS CLI, create an AWS profile named `pc-demo`:
+Using the AWS CLI, create an AWS profile named `geotrellis`:
 
 ```bash
 $ vagrant ssh
-vagrant@vagrant-ubuntu-trusty-64:~$ aws --profile pc-demo configure
+vagrant@vagrant-ubuntu-trusty-64:~$ aws --profile geotrellis configure
 AWS Access Key ID [********************]:
 AWS Secret Access Key [********************]:
 Default region name [us-east-1]: us-east-1
@@ -27,16 +27,21 @@ You will be prompted to enter your AWS credentials, along with a default region.
 Next, use the `infra` wrapper script to lookup the remote state of the infrastructure and assemble a plan for work to be done:
 
 ```bash
-vagrant@vagrant-ubuntu-trusty-64:~$ export PGW_COMMUNITY_MAPPING_SETTINGS_BUCKET="staging-pgw-cm-config-us-east-1"
-vagrant@vagrant-ubuntu-trusty-64:~$ export PGW_COMMUNITY_MAPPING_SITE_BUCKET="staging-pgw-cm-site-us-east-1"
-vagrant@vagrant-ubuntu-trusty-64:~$ export AWS_PROFILE="pgw-cm-stg"
-vagrant@vagrant-ubuntu-trusty-64:~$ ./scripts/infra.sh plan
+# TRAVIS_COMMIT is the 7-digit SHA of the commit you wish to deploy
+$ export TRAVIS_COMMIT=1a2b3c4
+$ export PC_DEMO_SETTINGS_BUCKET="geotrellis-site-production-config-us-east-1"
+$ export AWS_PROFILE="geotrellis"
+$ docker-compose -f docker-compose.ci.yml -f \
+	docker-compose.ci.override.yml run --rm terraform \
+	./scripts/infra.sh plan
 ```
 
 Once the plan has been assembled, and you agree with the changes, apply it:
 
 ```bash
-vagrant@vagrant-ubuntu-trusty-64:~$ ./scripts/infra.sh apply
+$ docker-compose -f docker-compose.ci.yml -f \
+	docker-compose.ci.override.yml run --rm terraform \
+	./scripts/infra.sh apply
 ```
 
 This will attempt to apply the plan assembled in the previous step using Amazon's APIs. In order to change specific attributes of the infrastructure, inspect the contents of the environment's configuration file in Amazon S3.

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -4,5 +4,5 @@ docker_compose_version: "1.16.0"
 
 shellcheck_version: "0.3.*"
 
-aws_profile: "pc-demo"
+aws_profile: "geotrellis"
 aws_cli_version: "1.11.30"

--- a/deployment/terraform/pointcloud-demo.tf
+++ b/deployment/terraform/pointcloud-demo.tf
@@ -21,7 +21,8 @@ resource "aws_ecs_task_definition" "pointcloud" {
 }
 
 resource "aws_cloudwatch_log_group" "pointcloud" {
-  name = "log${var.environment}PointCloudDemo"
+  name              = "log${var.environment}PointCloudDemo"
+  retention_in_days = "30"
 
   tags {
     Environment = "${var.environment}"

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -25,9 +25,7 @@ variable "cdn_price_class" {
   default = "PriceClass_200"
 }
 
-variable "ssl_certificate_arn" {
-  default = "arn:aws:acm:us-east-1:896538046175:certificate/a416c2af-00dd-4afd-8c71-dd32edefa839"
-}
+variable "ssl_certificate_arn" {}
 
 variable "pointcloud_ecs_desired_count" {
   default = "1"

--- a/docker-compose.ci.override.yml
+++ b/docker-compose.ci.override.yml
@@ -1,0 +1,11 @@
+version: '2.1'
+services:
+  terraform:
+    image: "quay.io/azavea/terraform:0.9.11"
+    volumes:
+      - ~/.aws:/root/.aws
+    environment:
+      - GT_TRANSIT_DEBUG=1
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_PROFILE=${AWS_PROFILE:-geotrellis}

--- a/scripts/infra.sh
+++ b/scripts/infra.sh
@@ -34,11 +34,15 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         case "${1}" in
             plan)
                 rm -rf .terraform/ terraform.tfstate*
+
+                aws s3 cp "s3://${PC_DEMO_SETTINGS_BUCKET}/terraform/pointcloud/terraform.tfvars" \
+                    "${PC_DEMO_SETTINGS_BUCKET}.tfvars"
                 terraform init \
                     -backend-config="bucket=${PC_DEMO_SETTINGS_BUCKET}" \
                     -backend-config="key=terraform/pointcloud/state"
 
                 terraform plan \
+                          -var-file="${PC_DEMO_SETTINGS_BUCKET}.tfvars" \
                           -var="image_version=\"${TRAVIS_COMMIT:0:7}\"" \
                           -var="remote_state_bucket=\"${PC_DEMO_SETTINGS_BUCKET}\"" \
                           -out="${PC_DEMO_SETTINGS_BUCKET}.tfplan"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -19,7 +19,7 @@ then
     then
         usage
     else
-        if ansible --version | grep -q "ansible 2.2."; then
+        if ansible --version | grep -q "ansible 2."; then
             mkdir -p data/
             vagrant up --provision
             vagrant ssh -c "cd /vagrant && ./scripts/update.sh"

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -31,5 +31,10 @@ then
         docker-compose \
             -f docker-compose.yml \
             run --rm --no-deps pc-assets
+
+        # Update scala dependencies
+        docker-compose \
+            -f docker-compose.yml \
+            run --rm --no-deps pc-api-server update
     fi
 fi


### PR DESCRIPTION
# Overview

This PR removes the default value for `ssl_certificate_arn` (which is now outdated) from `variables.tf`, and updates `scripts/infra` to use a .tfvars file to make it easier to override other defaults in the future. Additionally, I set a CloudWatch log retention policy and made some tweaks to the dev env setup

## Changes
- Remove default value for `ssl_certficate_arn`. That value is now provided to terraform via a tfvars file.
- Add `docker-compose.ci.override.yml` for local deployments.
- Loosen Ansible version constraints
- Make sure Scala dependencies are installed by `scripts/update`
- Set CloudWatch log retention policy to 30 days.

Fixes #14 
See azavea/operations#202

# Testing
- I deployed this PR from Travis. Build logs are [here](https://travis-ci.org/geotrellis/geotrellis-pointcloud-demo/builds/404549886).
- Run `scripts/infra` according to the instructions in the new deployment README, ensure no changes are necessary.
```bash
$ export PC_DEMO_SETTINGS_BUCKET=geotrellis-site-production-config-us-east-1
$ export AWS_PROFILE=geotrellis
$ export TRAVIS_COMMIT=0e3b2b4
$ docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra plan
```
